### PR TITLE
fix: invoke directly process.exit with uncaught fatal exception code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,9 +63,7 @@ var ThresholdReporter = function(baseReporterDecorator, config, logger, helper) 
 
     if(failedExpectation) {
       log.error('Failed minimum coverage threshold expectations');
-      process.on('exit', function() {
-        process.exit(1);
-      });
+      return process.exit(1);
     }
     done();
   };


### PR DESCRIPTION
This way we will immediately fail the process. It's specifically important when we use karma with grunt.